### PR TITLE
Ref: Handled stripe error and worked on no payment order.

### DIFF
--- a/smallslive/oscar_apps/checkout/views.py
+++ b/smallslive/oscar_apps/checkout/views.py
@@ -750,7 +750,10 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
         submission = self.build_submission()
         submission['payment_kwargs']['payment_method'] = payment_method
 
-        return self.submit(**submission)
+        with transaction.atomic():
+            return self.submit(**submission)
+
+        # return self.submit(**submission)
 
     def submit(self, user, basket,
                shipping_address, shipping_method,
@@ -930,15 +933,16 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
         try:
             stripe_api_key = self.get_stripe_payment_credentials()[2]
             order_kwargs.update({'order_type': basket.get_order_type()})
-            response = self.handle_order_placement(
-                order_number, user, basket, shipping_address, shipping_method,
-                shipping_charge, billing_address, order_total, **order_kwargs)
-          
-            # capture the payment here after successfull order place.
+
             stripe.PaymentIntent.capture(
                 reference,
                 api_key=stripe_api_key
             )
+
+            response = self.handle_order_placement(
+                order_number, user, basket, shipping_address, shipping_method,
+                shipping_charge, billing_address, order_total, **order_kwargs)
+
 
             return response
         except UnableToPlaceOrder as e:
@@ -953,6 +957,8 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
             amount = order_total.excl_tax
             if amount:
                 amount = int(amount * 100)
+            if user.is_authenticated:
+                order_kwargs['guest_email'] = user.email
             manage_order_error_email(
                 order_number= order_number,
                 first_name=first_name,
@@ -964,7 +970,15 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
             self.restore_frozen_basket()
             # refund the order if pyament is already done and order is not completed
             if amount and reference:
-                refund_id = self.refund_stripe_payment(reference, amount=amount)
+                try:
+                    refund_id = self.refund_stripe_payment(reference, amount=amount)
+                except Exception as exc:
+                    logger.error("Stripe refund error: %s", exc)
+                    messages.error(
+                        self.request,
+                        "Something went wrong while processing your payment. Please contact support."
+                    )
+                    return redirect("home")
                 if refund_id:
                     send_incompleted_order_refunded_email(
                         order_number= order_number,
@@ -972,11 +986,18 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
                         amount=order_total.excl_tax,
                         refund_id = refund_id
                     )
+                    messages.error(
+                        self.request,
+                        "We were unable to complete your order. Your payment has been refunded. Please try again later."
+                    )
             return self.render_preview(
                 self.request, error=msg, **payment_kwargs)
         except Exception as e:
             print(e)
+            msg = six.text_type(e)
             error_type = 'Global Exception'
+            if user.is_authenticated:
+                order_kwargs['guest_email'] = user.email
             manage_order_error_email(
                 order_number= order_number,
                 first_name=first_name,
@@ -990,7 +1011,15 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
                 amount = int(amount * 100)
             # refund the order if pyament is already done and order is not completed
             if amount and reference:
-                refund_id = self.refund_stripe_payment(reference, amount=amount)
+                try:
+                    refund_id = self.refund_stripe_payment(reference, amount=amount)
+                except Exception as exc:
+                    logger.error("Stripe refund error: %s", exc)
+                    messages.error(
+                        self.request,
+                        "Something went wrong while processing your payment. Please contact support."
+                    )
+                    return redirect("home")
                 if refund_id:
                     send_incompleted_order_refunded_email(
                         order_number= order_number,
@@ -998,6 +1027,12 @@ class PaymentDetailsView(PayPalMixin, StripeMixin, AssignProductMixin,
                         amount=order_total.excl_tax,
                         refund_id = refund_id
                     )
+                    messages.error(
+                        self.request,
+                        "We were unable to complete your order. Your payment has been refunded. Please try again later."
+                    )
+            return self.render_preview(
+                self.request, error=msg, **payment_kwargs)
 
     def get_item_list(self, basket_lines):
 


### PR DESCRIPTION
Existing Logic:
- The order was placed and the confirmation email was sent, but due to a Stripe capture error, the payment was not completed.

Fix Implemented (for both authenticated and anonymous users):
- Payment is now processed before order creation.
- If order creation fails due to a Stripe-related issue, the payment will be refunded.
- If the payment remains uncaptured, the process returns without issuing a refund and without creating the order.
- Also a fix for mail before refund logic for logged in users.